### PR TITLE
Update `aggregate()` in design principles vignette

### DIFF
--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -73,7 +73,7 @@ A list of `contactmatrix` from different settings, or just different runs of the
 
 - [ ] Helper to convert to long format;
 - [ ] Helper to transform and interpolate between ages in bins of various sizes.
-- [x] Helper to summarise a contactmatrix_list into a contactmatrix (`aggregate_contactmatrix_list()`)
+- [x] Helper to summarise a contactmatrix_list into a contactmatrix (`aggregate.contactmatrix_list()`)
 - [x] Helper to make the contact matrix symmetric (`cm_make_symmetric()`)
 - [ ] Helper to obtain the age bins and breaks (if present) in terms of a vector with min or max ages, but also a text-format for figure labels etc.
 

--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -68,12 +68,12 @@ A list of `contactmatrix` from different settings, or just different runs of the
 - [ ] `plot()` method for visualisation
 - [x] `print()` method for human-readable output:
     - [x] Show levels
+- [x] Summarise a `contactmatrix_list` into a `contactmatrix` (`aggregate.contactmatrix_list()`)
 
 ### Helpers
 
 - [ ] Helper to convert to long format;
 - [ ] Helper to transform and interpolate between ages in bins of various sizes.
-- [x] Helper to summarise a contactmatrix_list into a contactmatrix (`aggregate.contactmatrix_list()`)
 - [x] Helper to make the contact matrix symmetric (`cm_make_symmetric()`)
 - [ ] Helper to obtain the age bins and breaks (if present) in terms of a vector with min or max ages, but also a text-format for figure labels etc.
 


### PR DESCRIPTION
This PR closes #15 by updating bullet point on the `aggregate()` S3 method for the `contactmatrix_list` class. It is also moved from the **Helpers** section to **Custom methods**.